### PR TITLE
Added quriobot and affiliates` static resources to exclusion

### DIFF
--- a/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
+++ b/inc/Engine/Optimization/Minify/JS/AbstractJSOptimization.php
@@ -243,6 +243,11 @@ abstract class AbstractJSOptimization extends AbstractOptimization {
 			'booqable.com/v2/booqable.js',
 			'googleoptimize.com',
 			'cdna.hubpeople.com/js/widget_standalone_two_modes.js',
+			'static.botsrv2.com',
+			'static.botsrv.com',
+			'static.quriobot.com',
+			'static.ai.getdeardoc.com',
+			'static.bots.sefbot.cz',
 		];
 
 		$excluded_external = array_merge( $defaults, $this->options->get( 'exclude_js', [] ) );


### PR DESCRIPTION
## Description

WP-Rocket's minification breaks Quriobot widget script (which is already minified BTW).

```
Uncaught SyntaxError: Invalid regular expression: missing /
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)